### PR TITLE
Fix typo in package name from 'berkley-abc' to 'berkeley-abc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ _Generation and exploration of approximate circuits and accelerators has been a 
 ## Requirements:
 See [requirements.txt](requirements.txt) (you can modify the desired version, there is no strict limitation of the versions). 
 
-It is also necessary to have installed [ABC](https://github.com/berkeley-abc/abc) in the system and to be available as `berkley-abc` command. If you have a different location, please modify [autoax/abcsynth.py](autoax/abcsynth.py) file or make an alias. At debian-based linux you can install it by a command
+It is also necessary to have installed [ABC](https://github.com/berkeley-abc/abc) in the system and to be available as `berkeley-abc` command. If you have a different location, please modify [autoax/abcsynth.py](autoax/abcsynth.py) file or make an alias. At debian-based linux you can install it by a command
 
 ```bash
-sudo apt install berkley-abc
+sudo apt install berkeley-abc
 ```
 
 ## Example application


### PR DESCRIPTION
This pull request fixes a minor typo in the installation command for the Berkeley ABC package. The incorrect package name 'berkley-abc' is corrected to 'berkeley-abc' to ensure users do not encounter errors during installation. This typo was found in the main README.md and installation instructions. I've verified that this typo does not appear in other parts of the documentation.